### PR TITLE
Add `token_usage` and `pdf_path` keys to return dictionary

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -38,6 +38,7 @@ parse
    * ``parent_title``: Title of parent doc if recursively parsed
    * ``recursive_docs``: List of dictionaries for recursively parsed documents
    * ``token_usage``: Token usage statistics
+   * ``pdf_path``: Path to the intermediate PDF generated when ``as_pdf`` is enabled and the kwarg ``save_dir`` is specified.
 
 Examples
 --------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -30,13 +30,14 @@ parse
    * ``y_tolerance`` (int): Y-axis tolerance for text extraction
 
    Return value format:
-   A dictionary containing the following keys:
+   A dictionary containing a subset or all of the following keys:
    *  ``raw``: Full markdown content as string
    * ``segments``: List of dictionaries with metadata and content
    * ``title``: Title of the document
    * ``url``: URL if applicable
    * ``parent_title``: Title of parent doc if recursively parsed
    * ``recursive_docs``: List of dictionaries for recursively parsed documents
+   * ``token_usage``: Token usage statistics
 
 Examples
 --------

--- a/lexoid/api.py
+++ b/lexoid/api.py
@@ -142,12 +142,15 @@ def parse(
 
         if path.startswith(("http://", "https://")):
             kwargs["url"] = path
-            download_dir = os.path.join(temp_dir, "downloads/")
+            download_dir = kwargs.get("save_dir", os.path.join(temp_dir, "downloads/"))
             os.makedirs(download_dir, exist_ok=True)
             if is_supported_url_file_type(path):
                 path = download_file(path, download_dir)
             elif as_pdf:
-                pdf_path = os.path.join(download_dir, f"webpage_{int(time())}.pdf")
+                pdf_filename = kwargs.get("save_filename", f"webpage_{int(time())}.pdf")
+                if not pdf_filename.endswith(".pdf"):
+                    pdf_filename += ".pdf"
+                pdf_path = os.path.join(download_dir, pdf_filename)
                 path = convert_to_pdf(path, pdf_path)
             else:
                 return recursive_read_html(path, depth)
@@ -200,6 +203,8 @@ def parse(
                     "total": sum(r["token_usage"]["total"] for r in chunk_results),
                 },
             }
+            if as_pdf:
+                result["pdf_path"] = path
 
     if depth > 1:
         recursive_docs = []

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -214,3 +214,33 @@ async def test_large_pdf_parsing(sample):
     results = parse(file_name, parser_type, pages_per_split=1)["segments"]
     assert len(results) == n_pages
     assert results[0]["content"] is not None
+
+
+@pytest.mark.asyncio
+async def test_token_usage():
+    sample = "examples/inputs/test_1.pdf"
+    parser_type = "LLM_PARSE"
+    token_usage = parse(sample, parser_type)["token_usage"]
+    assert token_usage["input"] > 0
+    assert token_usage["output"] > 0
+    assert token_usage["total"] > 0
+
+
+@pytest.mark.asyncio
+def test_pdf_save_path():
+    sample = "https://example.com/"
+    parser_type = "LLM_PARSE"
+    result = parse(
+        sample,
+        parser_type,
+        as_pdf=True,
+        save_dir="tests/outputs/temp",
+        save_filename="test_output.pdf",
+    )
+    assert "pdf_path" in result
+    assert result["pdf_path"].endswith(".pdf")
+    assert os.path.exists(result["pdf_path"])
+
+    # Clean up
+    os.remove(result["pdf_path"])
+    os.rmdir("tests/outputs/temp")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,6 +5,7 @@ import os
 
 import pytest
 from dotenv import load_dotenv
+from loguru import logger
 
 from lexoid.api import parse
 from lexoid.core.utils import calculate_similarity
@@ -216,11 +217,26 @@ async def test_large_pdf_parsing(sample):
     assert results[0]["content"] is not None
 
 
+token_usage_models = [
+    # Google models
+    "gemini-2.0-flash-001",
+    # OpenAI models
+    "gpt-4o",
+    # Meta-LLAMA models through HF Hub
+    "meta-llama/Llama-3.2-11B-Vision-Instruct",
+    # Meta-LLAMA models through Together AI
+    "meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo",
+]
+
+
+@pytest.mark.parametrize("model", token_usage_models)
 @pytest.mark.asyncio
-async def test_token_usage():
+async def test_token_usage_api(model):
     sample = "examples/inputs/test_1.pdf"
     parser_type = "LLM_PARSE"
-    token_usage = parse(sample, parser_type)["token_usage"]
+    config = {"parser_type": parser_type, "model": model}
+    token_usage = parse(sample, **config)["token_usage"]
+    logger.info(f"Token usage: {token_usage}")
     assert token_usage["input"] > 0
     assert token_usage["output"] > 0
     assert token_usage["total"] > 0


### PR DESCRIPTION
* `token_usage`: A dictionary containing the input, output, and total token count.
   - The token counts specified in the top-level dictionary are the sums across all the child segments.
   - Where applicable, each segment will also have the `token_usage` inside the `metadata` dictionary. (This will not be the case when the model is a Gemini model and `pages_per_split>1` as the segments would be parsed in groups).
   - If a webpage is being recursively parsed and `as_pdf=True`, then all recursively parsed docs will also contain a token count. These token counts are NOT added to the top-level dictionary's token counts.
* `pdf_path`: A string containing the path to the intermediate PDF created when `as_pdf=True` and the keyword argument `save_dir` is specified (because this keeps the PDF persistent).
   - If the keyword argument `save_filename` is specified, it will override the automatically generated file name.