### PR TITLE
Add param to specify page numbers to parse

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -28,6 +28,8 @@ parse
    * ``verbose`` (bool): Enable verbose logging
    * ``x_tolerance`` (int): X-axis tolerance for text extraction
    * ``y_tolerance`` (int): Y-axis tolerance for text extraction
+   * ``save_dir`` (str): Directory to save intermediate PDFs
+   * ``page_nums`` (List[int]): List of page numbers to parse
 
    Return value format:
    A dictionary containing a subset or all of the following keys:

--- a/lexoid/api.py
+++ b/lexoid/api.py
@@ -19,6 +19,7 @@ from lexoid.core.utils import (
     recursive_read_html,
     router,
     split_pdf,
+    create_sub_pdf,
 )
 
 
@@ -162,6 +163,12 @@ def parse(
         if as_pdf and not path.lower().endswith(".pdf"):
             pdf_path = os.path.join(temp_dir, "converted.pdf")
             path = convert_to_pdf(path, pdf_path)
+
+        if "page_nums" in kwargs and path.lower().endswith(".pdf"):
+            sub_pdf_dir = os.path.join(temp_dir, "sub_pdfs")
+            os.makedirs(sub_pdf_dir, exist_ok=True)
+            sub_pdf_path = os.path.join(sub_pdf_dir, f"{os.path.basename(path)}")
+            path = create_sub_pdf(path, sub_pdf_path, kwargs["page_nums"])
 
         if not path.lower().endswith(".pdf") or parser_type == ParserType.STATIC_PARSE:
             kwargs["split"] = False

--- a/lexoid/core/utils.py
+++ b/lexoid/core/utils.py
@@ -6,7 +6,7 @@ import re
 import sys
 from difflib import SequenceMatcher
 from hashlib import md5
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 from urllib.parse import urlparse
 
 import nest_asyncio
@@ -46,7 +46,7 @@ def split_pdf(input_path: str, output_dir: str, pages_per_split: int):
 
 
 def create_sub_pdf(
-    input_path: str, output_path: str, page_nums: Optional[Union[tuple|int]] = None
+    input_path: str, output_path: str, page_nums: Optional[tuple[int, ...]|int] = None
 ) -> str:
     if isinstance(page_nums, int):
         page_nums = (page_nums,)

--- a/lexoid/core/utils.py
+++ b/lexoid/core/utils.py
@@ -6,7 +6,7 @@ import re
 import sys
 from difflib import SequenceMatcher
 from hashlib import md5
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 import nest_asyncio
@@ -46,8 +46,10 @@ def split_pdf(input_path: str, output_dir: str, pages_per_split: int):
 
 
 def create_sub_pdf(
-    input_path: str, output_path: str, page_nums: Optional[tuple] = None
+    input_path: str, output_path: str, page_nums: Optional[Union[tuple|int]] = None
 ) -> str:
+    if isinstance(page_nums, int):
+        page_nums = (page_nums,)
     with pikepdf.open(input_path) as pdf:
         indices = page_nums if page_nums else range(len(pdf.pages))
         with pikepdf.new() as new_pdf:

--- a/lexoid/core/utils.py
+++ b/lexoid/core/utils.py
@@ -50,6 +50,7 @@ def create_sub_pdf(
 ) -> str:
     if isinstance(page_nums, int):
         page_nums = (page_nums,)
+    page_nums = tuple(sorted(set(page_nums)))
     with pikepdf.open(input_path) as pdf:
         indices = page_nums if page_nums else range(len(pdf.pages))
         with pikepdf.new() as new_pdf:

--- a/lexoid/core/utils.py
+++ b/lexoid/core/utils.py
@@ -6,7 +6,7 @@ import re
 import sys
 from difflib import SequenceMatcher
 from hashlib import md5
-from typing import Dict, List
+from typing import Dict, List, Optional
 from urllib.parse import urlparse
 
 import nest_asyncio
@@ -43,6 +43,17 @@ def split_pdf(input_path: str, output_dir: str, pages_per_split: int):
                 new_pdf.save(output_path)
                 paths.append(output_path)
     return paths
+
+
+def create_sub_pdf(
+    input_path: str, output_path: str, page_nums: Optional[tuple] = None
+) -> str:
+    with pikepdf.open(input_path) as pdf:
+        indices = page_nums if page_nums else range(len(pdf.pages))
+        with pikepdf.new() as new_pdf:
+            new_pdf.pages.extend([pdf.pages[i - 1] for i in indices])
+            new_pdf.save(output_path)
+    return output_path
 
 
 def convert_image_to_pdf(image_path: str) -> bytes:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -243,7 +243,7 @@ async def test_token_usage_api(model):
 
 
 @pytest.mark.asyncio
-def test_pdf_save_path():
+async def test_pdf_save_path():
     sample = "https://example.com/"
     parser_type = "LLM_PARSE"
     result = parse(
@@ -263,7 +263,7 @@ def test_pdf_save_path():
 
 
 @pytest.mark.asyncio
-def test_page_nums():
+async def test_page_nums():
     sample = "examples/inputs/sample_test_doc.pdf"
     result = parse(sample, "LLM_PARSE", page_nums=(3, 4), pages_per_split=1)
     assert len(result["segments"]) == 2

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -270,6 +270,10 @@ async def test_page_nums():
     assert all(keyword in result["raw"] for keyword in ["Table 24", "apple"])
     assert all(keyword not in result["raw"] for keyword in ["Aenean", "Lexoid"])
 
+    result = parse(sample, "LLM_PARSE", page_nums=(3, 3), pages_per_split=1)
+    assert len(result["segments"]) == 1
+    assert "Table 24" in result["raw"]
+
     sample = "https://www.dca.ca.gov/acp/pdf_files/lemonlaw_qa.pdf"
     result = parse(sample, "STATIC_PARSE", page_nums=2, pages_per_split=1)
     assert len(result["segments"]) == 1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -271,7 +271,7 @@ async def test_page_nums():
     assert all(keyword not in result["raw"] for keyword in ["Aenean", "Lexoid"])
 
     sample = "https://www.dca.ca.gov/acp/pdf_files/lemonlaw_qa.pdf"
-    result = parse(sample, "STATIC_PARSE", page_nums=(2,), pages_per_split=1)
+    result = parse(sample, "STATIC_PARSE", page_nums=2, pages_per_split=1)
     assert len(result["segments"]) == 1
     assert "ATTEMPTS" in result["raw"]
     assert "acp@dca.ca.gov" not in result["raw"]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -260,3 +260,13 @@ def test_pdf_save_path():
     # Clean up
     os.remove(result["pdf_path"])
     os.rmdir("tests/outputs/temp")
+
+
+@pytest.mark.asyncio
+def test_page_nums():
+    sample = "examples/inputs/sample_test_doc.pdf"
+    parser_type = "LLM_PARSE"
+    result = parse(sample, parser_type, page_nums=(3, 4), pages_per_split=1)
+    assert len(result["segments"]) == 2
+    assert all(keyword in result["raw"] for keyword in ["Table 24", "apple"])
+    assert all(keyword not in result["raw"] for keyword in ["Aenean", "Lexoid"])

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -265,8 +265,13 @@ def test_pdf_save_path():
 @pytest.mark.asyncio
 def test_page_nums():
     sample = "examples/inputs/sample_test_doc.pdf"
-    parser_type = "LLM_PARSE"
-    result = parse(sample, parser_type, page_nums=(3, 4), pages_per_split=1)
+    result = parse(sample, "LLM_PARSE", page_nums=(3, 4), pages_per_split=1)
     assert len(result["segments"]) == 2
     assert all(keyword in result["raw"] for keyword in ["Table 24", "apple"])
     assert all(keyword not in result["raw"] for keyword in ["Aenean", "Lexoid"])
+
+    sample = "https://www.dca.ca.gov/acp/pdf_files/lemonlaw_qa.pdf"
+    result = parse(sample, "STATIC_PARSE", page_nums=(2,), pages_per_split=1)
+    assert len(result["segments"]) == 1
+    assert "ATTEMPTS" in result["raw"]
+    assert "acp@dca.ca.gov" not in result["raw"]


### PR DESCRIPTION
The `parse` function now takes a keyword argument called `page_nums` whose value is expected to be a tuple of integers corresponding to a subset of pages that should be parsed. A "sub-pdf" with the specified page numbers are created and used for parsing.