### PR TITLE
Fix seg fault when PyQT app reinitialization

### DIFF
--- a/lexoid/core/utils.py
+++ b/lexoid/core/utils.py
@@ -473,7 +473,10 @@ def save_webpage_as_pdf(url: str, output_path: str) -> str:
     Returns:
         str: The path to the saved PDF file.
     """
-    app = QApplication(sys.argv)
+    if not QApplication.instance():
+        app = QApplication(sys.argv)
+    else:
+        app = QApplication.instance()
     web = QWebEngineView()
     web.load(QUrl(url))
 


### PR DESCRIPTION
When running `parse` on a webpage multiple times with `as_pdf=True`, it causes a segmentation fault. Reusing the existing `QApplication` instance (without reinitialization) resolves the error.