### PR TITLE
Add support for OpenRouter models

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,10 @@ _Note:_ Benchmarks are currently done in the zero-shot setting.
 | 6    | gemini-1.5-pro                                        | 0.732           | 0.265     | 11.44    |
 | 7    | gpt-4o                                                | 0.687           | 0.247     | 10.16    |
 | 8    | gpt-4o-mini                                           | 0.642           | 0.213     | 9.71     |
-| 9    | gemini-1.5-flash-8b                                   | 0.551           | 0.223     | 3.91     |
-| 10   | Llama-Vision-Free (via Together AI)                   | 0.531           | 0.198     | 6.93     |
-| 11   | Llama-3.2-11B-Vision-Instruct-Turbo (via Together AI) | 0.524           | 0.192     | 3.68     |
-| 12   | Llama-3.2-90B-Vision-Instruct-Turbo (via Together AI) | 0.461           | 0.306     | 19.26    |
-| 13   | Llama-3.2-11B-Vision-Instruct (via Hugging Face)      | 0.451           | 0.257     | 4.54     |
+| 9    | gemma-3-27b-it                                        | 0.628           | 0.299     | 18.79    |
+| 10   | gemini-1.5-flash-8b                                   | 0.551           | 0.223     | 3.91     |
+| 11   | Llama-Vision-Free (via Together AI)                   | 0.531           | 0.198     | 6.93     |
+| 12   | Llama-3.2-11B-Vision-Instruct-Turbo (via Together AI) | 0.524           | 0.192     | 3.68     |
+| 13   | qwen/qwen-2.5-vl-7b-instruct                          | 0.482           | 0.209     | 11.53    |
+| 14   | Llama-3.2-90B-Vision-Instruct-Turbo (via Together AI) | 0.461           | 0.306     | 19.26    |
+| 15   | Llama-3.2-11B-Vision-Instruct (via Hugging Face)      | 0.451           | 0.257     | 4.54     |

--- a/docs/benchmark.rst
+++ b/docs/benchmark.rst
@@ -118,26 +118,36 @@ Here are the detailed parsing performance results for various models:
      - 0.213
      - 9.71
    * - 9
+     - gemma-3-27b-it
+     - 0.628
+     - 0.299
+     - 18.79
+   * - 10
      - gemini-1.5-flash-8b
      - 0.551
      - 0.223
      - 3.91
-   * - 10
+   * - 11
      - Llama-Vision-Free (via Together AI)
      - 0.531
      - 0.198
      - 6.93
-   * - 11
+   * - 12
      - Llama-3.2-11B-Vision-Instruct-Turbo (via Together AI)
      - 0.524
      - 0.192
      - 3.68
-   * - 12
+   * - 13
+     - qwen/qwen-2.5-vl-7b-instruct
+     - 0.482
+     - 0.209
+     - 11.53
+   * - 14
      - Llama-3.2-90B-Vision-Instruct-Turbo (via Together AI)
      - 0.461
      - 0.306
      - 19.26
-   * - 13
+   * - 15
      - Llama-3.2-11B-Vision-Instruct (via Hugging Face)
      - 0.451
      - 0.257

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -47,7 +47,11 @@ def get_input_output_pairs(input_path: str, output_dir: str) -> List[Tuple[str, 
 
 
 def run_benchmark_config(
-    input_path: str, ground_truth: str, config: Dict, output_save_dir: str = None, iterations: int = 1
+    input_path: str,
+    ground_truth: str,
+    config: Dict,
+    output_save_dir: str = None,
+    iterations: int = 1,
 ) -> BenchmarkResult:
     """Run a single benchmark configuration for a specified number of iterations."""
     similarities = []
@@ -63,10 +67,12 @@ def run_benchmark_config(
             if output_save_dir:
                 filename = (
                     f"{Path(input_path).stem}_"
-                    + ", ".join([
-                        f"{key}={str(value).replace('/', '_')}"
-                        for key, value in config.items()
-                    ])
+                    + ", ".join(
+                        [
+                            f"{key}={str(value).replace('/', '_')}"
+                            for key, value in config.items()
+                        ]
+                    )
                     + ".md"
                 )
                 with open(os.path.join(output_save_dir, filename), "w") as fp:
@@ -143,6 +149,9 @@ def generate_test_configs(input_path: str, test_attributes: List[str]) -> List[D
             "meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo",
             "meta-llama/Llama-3.2-90B-Vision-Instruct-Turbo",
             "meta-llama/Llama-Vision-Free",
+            # Model through OpenRouter
+            "google/gemma-3-27b-it",
+            "qwen/qwen-2.5-vl-7b-instruct",
         ],
         "framework": ["pdfminer", "pdfplumber"],
         "pages_per_split": [1, 2, 4, 8],
@@ -232,12 +241,14 @@ def format_results(results: List[BenchmarkResult], test_attributes: List[str]) -
         row = [str(i)]
         for attr in test_attributes:
             row.append(str(config.get(attr, "-")))
-        row.extend([
-            f"{result.similarity[0]:.3f}",
-            f"{result.similarity[1]:.3f}",
-            f"{result.execution_time[0]:.2f}",
-            error_msg,
-        ])
+        row.extend(
+            [
+                f"{result.similarity[0]:.3f}",
+                f"{result.similarity[1]:.3f}",
+                f"{result.execution_time[0]:.2f}",
+                error_msg,
+            ]
+        )
         md_lines.append("| " + " | ".join(row) + " |")
 
     return "\n".join(md_lines)


### PR DESCRIPTION
This PR adds support for running OpenRouter models using the OpenAI python client.
Also, ran the benchmark on `gemma-3-27b-it` and `qwen/qwen-2.5-vl-7b-instruct` through the OpenRouter API.