### PR TITLE
Add support for Fireworks API

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ print(parsed_md)
 * Hugging Face
 * Together AI
 * OpenRouter
+* Fireworks
 
 ## Benchmark
 
@@ -116,21 +117,23 @@ Results aggregated across 5 iterations each for 5 documents.
 
 _Note:_ Benchmarks are currently done in the zero-shot setting.
 
-| Rank | Model                                                 | Mean Similarity | Std. Dev. | Time (s) | Cost($)  |
-| ---- | ----------------------------------------------------- | --------------- | --------- | -------- | -------- |
-| 1    | gemini-2.0-flash                                      | 0.829           | 0.102     | 7.41     | 0.000480 |
-| 2    | gemini-2.0-flash-001                                  | 0.814           | 0.176     | 6.85     | 0.000421 |
-| 3    | gemini-1.5-flash                                      | 0.797           | 0.143     | 9.54     | 0.000238 |
-| 4    | gemini-2.0-pro-exp                                    | 0.764           | 0.227     | 11.95    |   TBA    |
-| 5    | gemini-2.0-flash-thinking-exp                         | 0.746           | 0.266     | 10.46    |   TBA    |
-| 6    | gemini-1.5-pro                                        | 0.732           | 0.265     | 11.44    | 0.003332 |
-| 7    | gpt-4o                                                | 0.687           | 0.247     | 10.16    | 0.004736 |
-| 8    | gpt-4o-mini                                           | 0.642           | 0.213     | 9.71     | 0.000275 |
-| 9    | gemma-3-27b-it (via OpenRouter)                       | 0.628           | 0.299     | 18.79    | 0.000096 |
-| 10   | gemini-1.5-flash-8b                                   | 0.551           | 0.223     | 3.91     | 0.000055 |
-| 11   | Llama-Vision-Free (via Together AI)                   | 0.531           | 0.198     | 6.93     | 0        |
-| 12   | Llama-3.2-11B-Vision-Instruct-Turbo (via Together AI) | 0.524           | 0.192     | 3.68     | 0.000060 |
-| 13   | qwen/qwen-2.5-vl-7b-instruct (via OpenRouter)         | 0.482           | 0.209     | 11.53    | 0.000052 |
-| 14   | Llama-3.2-90B-Vision-Instruct-Turbo (via Together AI) | 0.461           | 0.306     | 19.26    | 0.000426 |
-| 15   | Llama-3.2-11B-Vision-Instruct (via Hugging Face)      | 0.451           | 0.257     | 4.54     |   0      |
-| 16   | microsoft/phi-4-multimodal-instruct (via OpenRouter)  | 0.366           | 0.287     | 10.80    | 0.000019 |
+| Rank | Model | Mean Similarity | Std. Dev. | Time (s) | Cost ($) |
+| --- | --- | --- | --- | --- | --- |
+| 1 | gemini-2.0-flash | 0.829 | 0.102 | 7.41 | 0.00048 |
+| 2 | gemini-2.0-flash-001 | 0.814 | 0.176 | 6.85 | 0.000421 |
+| 3 | gemini-1.5-flash | 0.797 | 0.143 | 9.54 | 0.000238 |
+| 4 | gemini-2.0-pro-exp | 0.764 | 0.227 | 11.95 | TBA |
+| 5 | gemini-2.0-flash-thinking-exp | 0.746 | 0.266 | 10.46 | TBA |
+| 6 | gemini-1.5-pro | 0.732 | 0.265 | 11.44 | 0.003332 |
+| 7 | accounts/fireworks/models/llama4-maverick-instruct-basic (via Fireworks) | 0.687 | 0.221 | 8.07 | 0.000419 |
+| 8 | gpt-4o | 0.687 | 0.247 | 10.16 | 0.004736 |
+| 9 | accounts/fireworks/models/llama4-scout-instruct-basic (via Fireworks) | 0.675 | 0.184 | 5.98 | 0.000226 |
+| 10 | gpt-4o-mini | 0.642 | 0.213 | 9.71 | 0.000275 |
+| 11 | gemma-3-27b-it (via OpenRouter) | 0.628 | 0.299 | 18.79 | 0.000096 |
+| 12 | gemini-1.5-flash-8b | 0.551 | 0.223 | 3.91 | 0.000055 |
+| 13 | Llama-Vision-Free (via Together AI) | 0.531 | 0.198 | 6.93 | 0 |
+| 14 | Llama-3.2-11B-Vision-Instruct-Turbo (via Together AI) | 0.524 | 0.192 | 3.68 | 0.00006 |
+| 15 | qwen/qwen-2.5-vl-7b-instruct (via OpenRouter) | 0.482 | 0.209 | 11.53 | 0.000052 |
+| 16 | Llama-3.2-90B-Vision-Instruct-Turbo (via Together AI) | 0.461 | 0.306 | 19.26 | 0.000426 |
+| 17 | Llama-3.2-11B-Vision-Instruct (via Hugging Face) | 0.451 | 0.257 | 4.54 | 0 |
+| 18 | microsoft/phi-4-multimodal-instruct (via OpenRouter) | 0.366 | 0.287 | 10.8 | 0.000019 |

--- a/README.md
+++ b/README.md
@@ -123,17 +123,18 @@ _Note:_ Benchmarks are currently done in the zero-shot setting.
 | 2 | gemini-2.0-flash-001 | 0.814 | 0.176 | 6.85 | 0.000421 |
 | 3 | gemini-1.5-flash | 0.797 | 0.143 | 9.54 | 0.000238 |
 | 4 | gemini-2.0-pro-exp | 0.764 | 0.227 | 11.95 | TBA |
-| 5 | gemini-2.0-flash-thinking-exp | 0.746 | 0.266 | 10.46 | TBA |
-| 6 | gemini-1.5-pro | 0.732 | 0.265 | 11.44 | 0.003332 |
-| 7 | accounts/fireworks/models/llama4-maverick-instruct-basic (via Fireworks) | 0.687 | 0.221 | 8.07 | 0.000419 |
-| 8 | gpt-4o | 0.687 | 0.247 | 10.16 | 0.004736 |
-| 9 | accounts/fireworks/models/llama4-scout-instruct-basic (via Fireworks) | 0.675 | 0.184 | 5.98 | 0.000226 |
-| 10 | gpt-4o-mini | 0.642 | 0.213 | 9.71 | 0.000275 |
-| 11 | gemma-3-27b-it (via OpenRouter) | 0.628 | 0.299 | 18.79 | 0.000096 |
-| 12 | gemini-1.5-flash-8b | 0.551 | 0.223 | 3.91 | 0.000055 |
-| 13 | Llama-Vision-Free (via Together AI) | 0.531 | 0.198 | 6.93 | 0 |
-| 14 | Llama-3.2-11B-Vision-Instruct-Turbo (via Together AI) | 0.524 | 0.192 | 3.68 | 0.00006 |
-| 15 | qwen/qwen-2.5-vl-7b-instruct (via OpenRouter) | 0.482 | 0.209 | 11.53 | 0.000052 |
-| 16 | Llama-3.2-90B-Vision-Instruct-Turbo (via Together AI) | 0.461 | 0.306 | 19.26 | 0.000426 |
-| 17 | Llama-3.2-11B-Vision-Instruct (via Hugging Face) | 0.451 | 0.257 | 4.54 | 0 |
-| 18 | microsoft/phi-4-multimodal-instruct (via OpenRouter) | 0.366 | 0.287 | 10.8 | 0.000019 |
+| 5 | AUTO | 0.76 | 0.184 | 5.14 | 0.000217 |
+| 6 | gemini-2.0-flash-thinking-exp | 0.746 | 0.266 | 10.46 | TBA |
+| 7 | gemini-1.5-pro | 0.732 | 0.265 | 11.44 | 0.003332 |
+| 8 | accounts/fireworks/models/llama4-maverick-instruct-basic (via Fireworks) | 0.687 | 0.221 | 8.07 | 0.000419 |
+| 9 | gpt-4o | 0.687 | 0.247 | 10.16 | 0.004736 |
+| 10 | accounts/fireworks/models/llama4-scout-instruct-basic (via Fireworks) | 0.675 | 0.184 | 5.98 | 0.000226 |
+| 11 | gpt-4o-mini | 0.642 | 0.213 | 9.71 | 0.000275 |
+| 12 | gemma-3-27b-it (via OpenRouter) | 0.628 | 0.299 | 18.79 | 0.000096 |
+| 13 | gemini-1.5-flash-8b | 0.551 | 0.223 | 3.91 | 0.000055 |
+| 14 | Llama-Vision-Free (via Together AI) | 0.531 | 0.198 | 6.93 | 0 |
+| 15 | Llama-3.2-11B-Vision-Instruct-Turbo (via Together AI) | 0.524 | 0.192 | 3.68 | 0.00006 |
+| 16 | qwen/qwen-2.5-vl-7b-instruct (via OpenRouter) | 0.482 | 0.209 | 11.53 | 0.000052 |
+| 17 | Llama-3.2-90B-Vision-Instruct-Turbo (via Together AI) | 0.461 | 0.306 | 19.26 | 0.000426 |
+| 18 | Llama-3.2-11B-Vision-Instruct (via Hugging Face) | 0.451 | 0.257 | 4.54 | 0 |
+| 19 | microsoft/phi-4-multimodal-instruct (via OpenRouter) | 0.366 | 0.287 | 10.8 | 0.000019 |

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -32,7 +32,8 @@ parse
    * ``page_nums`` (List[int]): List of page numbers to parse
    * ``api_cost_mapping`` (Union[dict, str]): Dictionary containing API cost details or the string path to a JSON file containing
      the cost details. Sample file available at ``tests/api_cost_mapping.json``
-   * ``router_priority`` (str): What the routing strategy should prioritize. Options are ``"speed"`` and ``"accuracy"``. The router directs a file to either ``STATIC_PARSE`` or ``LLM_PARSE`` based on its type and the selected priority. If priority is "accuracy", it prefers LLM_PARSE unless the PDF has no images but contains embedded/hidden hyperlinks, in which case it uses ``STATIC_PARSE`` (because LLMs currently fail to parse hidden hyperlinks). If priority is "speed", it uses ``STATIC_PARSE`` for documents without images and ``LLM_PARSE`` for documents with images.
+   * ``router_priority`` (str): What the routing strategy should prioritize. Options are ``"speed"`` and ``"accuracy"``. The router directs a file to either ``"STATIC_PARSE"`` or ``"LLM_PARSE"`` based on its type and the selected priority. If priority is "accuracy", it prefers LLM_PARSE unless the PDF has no images but contains embedded/hidden hyperlinks, in which case it uses ``STATIC_PARSE`` (because LLMs currently fail to parse hidden hyperlinks). If priority is "speed", it uses ``STATIC_PARSE`` for documents without images and ``LLM_PARSE`` for documents with images.
+   * ``api_provider`` (str): The API provider to use for LLM parsing. Options are ``openai``, ``huggingface``, ``togetherai``, ``openrouter``, and ``fireworks``. This parameter is only relevant when using LLM parsing.
 
    Return value format:
    A dictionary containing a subset or all of the following keys:

--- a/docs/benchmark.csv
+++ b/docs/benchmark.csv
@@ -1,0 +1,19 @@
+Model,Mean Similarity,Std. Dev.,Time (s),Cost($)
+gemini-2.0-flash,0.829,0.102,7.41,0.00048
+gemini-2.0-flash-001,0.814,0.176,6.85,0.000421
+gemini-1.5-flash,0.797,0.143,9.54,0.000238
+gemini-2.0-pro-exp,0.764,0.227,11.95,TBA
+gemini-2.0-flash-thinking-exp,0.746,0.266,10.46,TBA
+gemini-1.5-pro,0.732,0.265,11.44,0.003332
+accounts/fireworks/models/llama4-maverick-instruct-basic (via Fireworks),0.687,0.221,8.07,0.000419
+gpt-4o,0.687,0.247,10.16,0.004736
+accounts/fireworks/models/llama4-scout-instruct-basic (via Fireworks),0.675,0.184,5.98,0.000226
+gpt-4o-mini,0.642,0.213,9.71,0.000275
+gemma-3-27b-it (via OpenRouter),0.628,0.299,18.79,0.000096
+gemini-1.5-flash-8b,0.551,0.223,3.91,0.000055
+Llama-Vision-Free (via Together AI),0.531,0.198,6.93,0
+Llama-3.2-11B-Vision-Instruct-Turbo (via Together AI),0.524,0.192,3.68,0.00006
+qwen/qwen-2.5-vl-7b-instruct (via OpenRouter),0.482,0.209,11.53,0.000052
+Llama-3.2-90B-Vision-Instruct-Turbo (via Together AI),0.461,0.306,19.26,0.000426
+Llama-3.2-11B-Vision-Instruct (via Hugging Face),0.451,0.257,4.54,0
+microsoft/phi-4-multimodal-instruct (via OpenRouter),0.366,0.287,10.8,0.000019

--- a/docs/benchmark.csv
+++ b/docs/benchmark.csv
@@ -3,6 +3,7 @@ gemini-2.0-flash,0.829,0.102,7.41,0.00048
 gemini-2.0-flash-001,0.814,0.176,6.85,0.000421
 gemini-1.5-flash,0.797,0.143,9.54,0.000238
 gemini-2.0-pro-exp,0.764,0.227,11.95,TBA
+AUTO,0.760,0.184,5.14,0.000217
 gemini-2.0-flash-thinking-exp,0.746,0.266,10.46,TBA
 gemini-1.5-pro,0.732,0.265,11.44,0.003332
 accounts/fireworks/models/llama4-maverick-instruct-basic (via Fireworks),0.687,0.221,8.07,0.000419

--- a/docs/benchmark.rst
+++ b/docs/benchmark.rst
@@ -103,84 +103,90 @@ Here are the detailed parsing performance results for various models:
      - 11.95
      - TBA
    * - 5
+     - AUTO
+     - 0.76
+     - 0.184
+     - 5.14
+     - 0.000217
+   * - 6
      - gemini-2.0-flash-thinking-exp
      - 0.746
      - 0.266
      - 10.46
      - TBA
-   * - 6
+   * - 7
      - gemini-1.5-pro
      - 0.732
      - 0.265
      - 11.44
      - 0.003332
-   * - 7
+   * - 8
      - accounts/fireworks/models/llama4-maverick-instruct-basic (via Fireworks)
      - 0.687
      - 0.221
      - 8.07
      - 0.000419
-   * - 8
+   * - 9
      - gpt-4o
      - 0.687
      - 0.247
      - 10.16
      - 0.004736
-   * - 9
+   * - 10
      - accounts/fireworks/models/llama4-scout-instruct-basic (via Fireworks)
      - 0.675
      - 0.184
      - 5.98
      - 0.000226
-   * - 10
+   * - 11
      - gpt-4o-mini
      - 0.642
      - 0.213
      - 9.71
      - 0.000275
-   * - 11
+   * - 12
      - gemma-3-27b-it (via OpenRouter)
      - 0.628
      - 0.299
      - 18.79
      - 0.000096
-   * - 12
+   * - 13
      - gemini-1.5-flash-8b
      - 0.551
      - 0.223
      - 3.91
      - 0.000055
-   * - 13
+   * - 14
      - Llama-Vision-Free (via Together AI)
      - 0.531
      - 0.198
      - 6.93
      - 0
-   * - 14
+   * - 15
      - Llama-3.2-11B-Vision-Instruct-Turbo (via Together AI)
      - 0.524
      - 0.192
      - 3.68
      - 0.00006
-   * - 15
+   * - 16
      - qwen/qwen-2.5-vl-7b-instruct (via OpenRouter)
      - 0.482
      - 0.209
      - 11.53
      - 0.000052
-   * - 16
+   * - 17
      - Llama-3.2-90B-Vision-Instruct-Turbo (via Together AI)
      - 0.461
      - 0.306
      - 19.26
      - 0.000426
-   * - 17
+   * - 18
      - Llama-3.2-11B-Vision-Instruct (via Hugging Face)
      - 0.451
      - 0.257
      - 4.54
      - 0
-   * - 18
+   * - 19
      - microsoft/phi-4-multimodal-instruct (via OpenRouter)
      - 0.366
      - 0.287

--- a/docs/benchmark.rst
+++ b/docs/benchmark.rst
@@ -83,7 +83,7 @@ Here are the detailed parsing performance results for various models:
      - 0.829
      - 0.102
      - 7.41
-     - 0.000480
+     - 0.00048
    * - 2
      - gemini-2.0-flash-001
      - 0.814
@@ -115,63 +115,75 @@ Here are the detailed parsing performance results for various models:
      - 11.44
      - 0.003332
    * - 7
+     - accounts/fireworks/models/llama4-maverick-instruct-basic (via Fireworks)
+     - 0.687
+     - 0.221
+     - 8.07
+     - 0.000419
+   * - 8
      - gpt-4o
      - 0.687
      - 0.247
      - 10.16
      - 0.004736
-   * - 8
+   * - 9
+     - accounts/fireworks/models/llama4-scout-instruct-basic (via Fireworks)
+     - 0.675
+     - 0.184
+     - 5.98
+     - 0.000226
+   * - 10
      - gpt-4o-mini
      - 0.642
      - 0.213
      - 9.71
      - 0.000275
-   * - 9
-     - google/gemma-3-27b-it
+   * - 11
+     - gemma-3-27b-it (via OpenRouter)
      - 0.628
      - 0.299
      - 18.79
      - 0.000096
-   * - 10
+   * - 12
      - gemini-1.5-flash-8b
      - 0.551
      - 0.223
      - 3.91
      - 0.000055
-   * - 11
+   * - 13
      - Llama-Vision-Free (via Together AI)
      - 0.531
      - 0.198
      - 6.93
      - 0
-   * - 12
+   * - 14
      - Llama-3.2-11B-Vision-Instruct-Turbo (via Together AI)
      - 0.524
      - 0.192
      - 3.68
-     - 0.000060
-   * - 13
-     - qwen/qwen-2.5-vl-7b-instruct
+     - 0.00006
+   * - 15
+     - qwen/qwen-2.5-vl-7b-instruct (via OpenRouter)
      - 0.482
      - 0.209
      - 11.53
      - 0.000052
-   * - 14
+   * - 16
      - Llama-3.2-90B-Vision-Instruct-Turbo (via Together AI)
      - 0.461
      - 0.306
      - 19.26
      - 0.000426
-   * - 15
+   * - 17
      - Llama-3.2-11B-Vision-Instruct (via Hugging Face)
      - 0.451
      - 0.257
      - 4.54
      - 0
-   * - 16
-     - microsoft/phi-4-multimodal-instruct
+   * - 18
+     - microsoft/phi-4-multimodal-instruct (via OpenRouter)
      - 0.366
      - 0.287
-     - 10.80
+     - 10.8
      - 0.000019
     

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,16 @@ Key Features
 * Parallel processing support
 * Permissive license
 
+Supported API Providers
+-----------------------
+
+* Google
+* OpenAI
+* Hugging Face
+* Together AI
+* OpenRouter
+* Fireworks
+
 Indices and tables
 ==================
 

--- a/docs/update_benchmarks.py
+++ b/docs/update_benchmarks.py
@@ -1,0 +1,66 @@
+import argparse
+import pandas as pd
+import re
+
+
+def update_markdown(content, table_md):
+    pattern = r"(##\s*Benchmark\s*\n(?:.*?\n)*?\n)(\| Rank .*?\n\|.*?\n(?:\|.*?\n)+)"
+    replacement = r"\1" + table_md + "\n"
+    return re.sub(pattern, replacement, content, flags=re.DOTALL)
+
+
+def update_rst(content, table_rst):
+    pattern = r"(Benchmark Results\s*-+\n.*?\n)(\s*\* - .*\n)+"
+    return re.sub(pattern, f"\\1{table_rst}\n", content, flags=re.DOTALL)
+
+
+def generate_markdown_table(df):
+    header = "| Rank | Model | Mean Similarity | Std. Dev. | Time (s) | Cost ($) |\n"
+    sep = "| --- | --- | --- | --- | --- | --- |\n"
+    rows = [
+        f"| {i+1} | {row['Model']} | {row['Mean Similarity']} | {row['Std. Dev.']} | {row['Time (s)']} | {row['Cost($)']} |"
+        for i, row in df.iterrows()
+    ]
+    return header + sep + "\n".join(rows)
+
+
+def generate_rst_table(df):
+    header = "\n   * - Rank\n     - Model\n     - Mean Similarity\n     - Std. Dev.\n     - Time (s)\n     - Cost ($)"
+    rows = [
+        f"   * - {i+1}\n     - {row['Model']}\n     - {row['Mean Similarity']}\n     - {row['Std. Dev.']}\n     - {row['Time (s)']}\n     - {row['Cost($)']}"
+        for i, row in df.iterrows()
+    ]
+    return header + "\n" + "\n".join(rows)
+
+
+def main(csv_path, md_path, rst_path):
+    df = pd.read_csv(csv_path)
+    df = df.sort_values(by="Mean Similarity", ascending=False).reset_index(drop=True)
+
+    with open(md_path, "r", encoding="utf-8") as f:
+        md_content = f.read()
+    with open(rst_path, "r", encoding="utf-8") as f:
+        rst_content = f.read()
+
+    table_md = generate_markdown_table(df)
+    table_rst = generate_rst_table(df)
+
+    updated_md = update_markdown(md_content, table_md)
+    updated_rst = update_rst(rst_content, table_rst)
+
+    with open(md_path, "w", encoding="utf-8") as f:
+        f.write(updated_md)
+    with open(rst_path, "w", encoding="utf-8") as f:
+        f.write(updated_rst)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Update benchmark tables in README.md and benchmark.rst from CSV"
+    )
+    parser.add_argument("--csv", default="benchmark.csv", help="Path to benchmark.csv")
+    parser.add_argument("--md", default="../README.md", help="Path to README.md")
+    parser.add_argument("--rst", default="benchmark.rst", help="Path to benchmark.rst")
+    args = parser.parse_args()
+
+    main(args.csv, args.md, args.rst)

--- a/lexoid/core/parse_type/llm_parser.py
+++ b/lexoid/core/parse_type/llm_parser.py
@@ -65,6 +65,8 @@ def parse_llm_doc(path: str, **kwargs) -> List[Dict] | str:
         return parse_with_api(path, api="huggingface", **kwargs)
     if any(model.startswith(prefix) for prefix in ["microsoft", "google", "qwen"]):
         return parse_with_api(path, api="openrouter", **kwargs)
+    if model.startswith("accounts/fireworks"):
+        return parse_with_api(path, api="fireworks", **kwargs)
     raise ValueError(f"Unsupported model: {model}")
 
 
@@ -191,6 +193,10 @@ def parse_with_api(path: str, api: str, **kwargs) -> List[Dict] | str:
         "openrouter": lambda: OpenAI(
             base_url="https://openrouter.ai/api/v1",
             api_key=os.environ["OPENROUTER_API_KEY"],
+        ),
+        "fireworks": lambda: OpenAI(
+            base_url="https://api.fireworks.ai/inference/v1",
+            api_key=os.environ["FIREWORKS_API_KEY"],
         ),
     }
     assert api in clients, f"Unsupported API: {api}"

--- a/lexoid/core/utils.py
+++ b/lexoid/core/utils.py
@@ -345,7 +345,7 @@ def get_webpage_soup(url: str) -> BeautifulSoup:
                 # Additional wait for any dynamic content
                 try:
                     await page.wait_for_selector("body", timeout=30000)
-                except:
+                except Exception:
                     pass
 
                 html = await page.content()
@@ -561,7 +561,11 @@ def router(path: str, priority: str = "speed") -> str:
         priority (str): The priority for routing: "accuracy" (preference to LLM_PARSE) or "speed" (preference to STATIC_PARSE).
     """
     file_type = get_file_type(path)
-    if file_type.startswith("text/") or "spreadsheet" in file_type or "presentation" in file_type:
+    if (
+        file_type.startswith("text/")
+        or "spreadsheet" in file_type
+        or "presentation" in file_type
+    ):
         return "STATIC_PARSE"
 
     if priority == "accuracy":

--- a/tests/api_cost_mapping.json
+++ b/tests/api_cost_mapping.json
@@ -59,5 +59,13 @@
         "input": 0.05,
         "input-image": 0.0001769,
         "output": 0.1
+    },
+    "accounts/fireworks/models/llama4-maverick-instruct-basic": {
+        "input": 0.22,
+        "output": 0.88
+    },
+    "accounts/fireworks/models/llama4-scout-instruct-basic": {
+        "input": 0.15,
+        "output": 0.6
     }
 }

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -164,6 +164,9 @@ def generate_test_configs(input_path: str, test_attributes: List[str]) -> List[D
             "google/gemma-3-27b-it",
             "qwen/qwen-2.5-vl-7b-instruct",
             "microsoft/phi-4-multimodal-instruct",
+            # Model through fireworks
+            "accounts/fireworks/models/llama4-maverick-instruct-basic",
+            "accounts/fireworks/models/llama4-scout-instruct-basic",
         ],
         "framework": ["pdfminer", "pdfplumber"],
         "pages_per_split": [1, 2, 4, 8],
@@ -290,7 +293,7 @@ def run_benchmarks(
     total_files = len(file_pairs)
 
     print(
-        f"Running {total_configs} configurations across {total_files} file{'s' if total_files > 1 else ''}..."
+        f"Running {total_configs} configurations across {total_files} file(s) for {iterations} iterations..."
     )
 
     for i, config in enumerate(configs, 1):

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -64,7 +64,15 @@ def run_benchmark_config(
         try:
             start_time = time.time()
             config["api_cost_mapping"] = "tests/api_cost_mapping.json"
-            result = parse(input_path, "LLM_PARSE", **config)
+            config["parse_type"] = config.get(
+                "parser_type",
+                (
+                    "LLM_PARSE"
+                    if "model" in config
+                    else ("STATIC_PARSE" if "framework" in config else "AUTO")
+                ),
+            )
+            result = parse(input_path, **config)
             execution_time = time.time() - start_time
 
             if output_save_dir:
@@ -141,7 +149,7 @@ def generate_test_configs(input_path: str, test_attributes: List[str]) -> List[D
     Generate different configuration combinations to test based on specified attributes.
     """
     config_options = {
-        "parser_type": ["LLM_PARSE", "STATIC_PARSE"],
+        "parser_type": ["LLM_PARSE", "STATIC_PARSE", "AUTO"],
         "model": [
             # Google models
             "gemini-2.0-pro-exp",


### PR DESCRIPTION
This PR adds support for the Fireworks API by introducing new Fireworks model entries in the benchmark configurations, updating the parser to route models starting with "accounts/fireworks" to the Fireworks API, and refreshing the documentation and update scripts accordingly.

- Added Fireworks model entries in tests/benchmark.py and updated the benchmark iteration message
- Routed Fireworks models in lexoid/core/parse_type/llm_parser.py to the appropriate API client
- Updated README.md and added docs/update_benchmarks.py to incorporate Fireworks support