### PR TITLE
Fix arxiv URL parsing

### DIFF
--- a/lexoid/api.py
+++ b/lexoid/api.py
@@ -218,7 +218,7 @@ def parse(
                 if not pdf_filename.endswith(".pdf"):
                     pdf_filename += ".pdf"
                 pdf_path = os.path.join(download_dir, pdf_filename)
-                logger.debug(f"Converting webpage to PDF: {pdf_path}")
+                logger.debug("Converting webpage to PDF...")
                 path = convert_to_pdf(path, pdf_path)
             else:
                 return recursive_read_html(path, depth)
@@ -229,6 +229,7 @@ def parse(
 
         if as_pdf and not path.lower().endswith(".pdf"):
             pdf_path = os.path.join(temp_dir, "converted.pdf")
+            logger.debug("Converting file to PDF")
             path = convert_to_pdf(path, pdf_path)
 
         if "page_nums" in kwargs and path.lower().endswith(".pdf"):

--- a/lexoid/core/utils.py
+++ b/lexoid/core/utils.py
@@ -85,7 +85,7 @@ def get_file_type(path: str) -> str:
 def is_supported_file_type(path: str) -> bool:
     """Check if the file type is supported for parsing."""
     file_type = get_file_type(path)
-    logger.debug(f"File type for {path}: {file_type}")
+    logger.debug(f"File type: {file_type}")
     if (
         file_type == "application/pdf"
         or "wordprocessing" in file_type
@@ -108,16 +108,7 @@ def is_supported_url_file_type(url: str) -> bool:
     Returns:
         bool: True if the file type is supported, False otherwise.
     """
-    supported_extensions = [
-        ".pdf",
-        ".png",
-        ".jpg",
-        ".jpeg",
-        ".tiff",
-        ".bmp",
-        ".gif",
-        ".txt",
-    ]
+    supported_extensions = [".pdf", ".png", ".jpg", ".jpeg", ".tiff", ".bmp", ".gif"]
     parsed_url = urlparse(url)
     ext = os.path.splitext(parsed_url.path)[1].lower()
 
@@ -146,16 +137,7 @@ def download_file(url: str, temp_dir: str) -> str:
     Returns:
         str: The path to the downloaded file.
     """
-    supported_extensions = [
-        ".pdf",
-        ".png",
-        ".jpg",
-        ".jpeg",
-        ".tiff",
-        ".bmp",
-        ".gif",
-        ".txt",
-    ]
+    supported_extensions = [".pdf", ".png", ".jpg", ".jpeg", ".tiff", ".bmp", ".gif"]
     response = requests.get(url)
     file_name = os.path.basename(urlparse(url).path)
     ext = os.path.splitext(file_name)[1].lower()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -174,11 +174,17 @@ async def test_parsing_txt_type():
 async def test_parsing_url_txt_type():
     sample_url = "https://www.justice.gov/archive/enron/exhibit/02-28/BBC-0001/OCR/EXH033-00243.TXT"
     parser_type = "AUTO"
-    results = parse(
+    results_1 = parse(
+        sample_url, parser_type, page_nums=1, pages_per_split=1, as_pdf=False
+    )["raw"]
+    assert len([results_1]) == 1
+    assert "David W Delainey" in results_1
+
+    results_2 = parse(
         sample_url, parser_type, page_nums=1, pages_per_split=1, as_pdf=True
     )["raw"]
-    assert len([results]) == 1
-    assert "David W Delainey" in results
+    assert len([results_2]) == 1
+    assert "David W Delainey" in results_2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Tests:
`.venv/bin/python3 -m pytest tests/test_parser.py::test_parsing_arxiv_url tests/test_parser.py::test_parsing_txt_type tests/test_parser.py::test_parsing_url_txt_type -v -s`

```
tests/test_parser.py::test_parsing_arxiv_url 2025-07-20 22:16:23.423 | DEBUG    | lexoid.core.utils:is_supported_file_type:88 - File type: application/pdf
2025-07-20 22:16:23.450 | DEBUG    | lexoid.core.utils:router:578 - Using STATIC_PARSE for PDF without images.
2025-07-20 22:16:23.450 | DEBUG    | lexoid.api:wrapper:50 - Auto-detected parser type: ParserType.STATIC_PARSE
2025-07-20 22:16:23.450 | DEBUG    | lexoid.api:parse_chunk:109 - Using static parser
PASSED
tests/test_parser.py::test_parsing_txt_type 2025-07-20 22:16:23.505 | DEBUG    | lexoid.core.utils:is_supported_file_type:88 - File type: text/plain
2025-07-20 22:16:23.505 | DEBUG    | lexoid.api:wrapper:50 - Auto-detected parser type: ParserType.STATIC_PARSE
2025-07-20 22:16:23.505 | DEBUG    | lexoid.api:parse_chunk:109 - Using static parser
PASSED
tests/test_parser.py::test_parsing_url_txt_type 2025-07-20 22:16:24.965 | DEBUG    | lexoid.api:parse:221 - Converting webpage to PDF...
PDF saved to: /var/folders/t8/1b1qg8xn3l54nczgqkp3c7bw0000gn/T/tmpb6f21dt7/downloads/webpage_1753074984.pdf
2025-07-20 22:16:25.459 | DEBUG    | lexoid.core.utils:is_supported_file_type:88 - File type: application/pdf
2025-07-20 22:16:25.461 | DEBUG    | lexoid.core.utils:router:578 - Using STATIC_PARSE for PDF without images.
2025-07-20 22:16:25.461 | DEBUG    | lexoid.api:wrapper:50 - Auto-detected parser type: ParserType.STATIC_PARSE
2025-07-20 22:16:25.461 | DEBUG    | lexoid.api:parse_chunk:109 - Using static parser
PASSED

===================3 passed in 6.52s ==============================================
```