### PR TITLE
Add a note on installing from virtual environment to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ playwright install --with-deps --only-shell chromium
 
 ### Building `.whl` from source
 
+>[!NOTE]
+>Installing the package from within the virtual environment could cause unexpected behavior, 
+>as Lexoid creates and activates its own environment in order to build the wheel.
+
 ```
 make build
 ```


### PR DESCRIPTION
Add a note that installing Lexoid from within virtual environment could cause unexpected behavior.