### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/oidlabs-com/Lexoid/security/code-scanning/1](https://github.com/oidlabs-com/Lexoid/security/code-scanning/1)

The correct way to fix this issue is to add a permissions block to the `build-docs` job, specifying the least privilege necessary for its steps. Since the job only checks out the code, builds documentation, and uploads as an artifact (none of which requires write access to the repository or its contents), it is sufficient to set permissions to `contents: read`. This should be done by adding

```yaml
permissions:
  contents: read
```

immediately under the `build-docs:` job definition, at the same indentation as `runs-on`. No methods, imports, or other definitions are required. Only the YAML code block in `.github/workflows/deploy_docs.yml` needs amending.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
